### PR TITLE
fix(SentimentAnalyzer): Use [ThreadStatic] and initialize once per thread

### DIFF
--- a/Cognitive-Library/SentimentAnalyzer.Tests/PredictTests.cs
+++ b/Cognitive-Library/SentimentAnalyzer.Tests/PredictTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace SentimentAnalyzer.Tests
+{
+    public class PredictTests
+    {
+        [Fact]
+        public void Should_Return_Negative_For_Negative_Sounding_Review()
+        {
+            var prediction = Sentiments.Predict("This is the worst product I've ever reviewed!").Prediction;
+
+            Assert.False(prediction);
+        }
+
+        [Fact]
+        public void Should_Return_Positive_For_Positive_Sounding_Review()
+        {
+            var prediction = Sentiments.Predict("This is the best product I've ever reviewed!").Prediction;
+
+            Assert.False(prediction);
+        }
+    }
+}

--- a/Cognitive-Library/SentimentAnalyzer/Sentiments.cs
+++ b/Cognitive-Library/SentimentAnalyzer/Sentiments.cs
@@ -15,9 +15,22 @@ namespace SentimentAnalyzer
     /// </summary>
     public sealed class Sentiments
     {
-        private static readonly Sentiments instance = new Sentiments();
+        [ThreadStatic]
+        private static Sentiments instance;
+
         private readonly PredictionEngine<Sentiment, SentimentPrediction> predictionEngine;
 
+        private static Sentiments Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new Sentiments();
+                }
+                return instance;
+            }
+        }
         /// <summary>
         /// Explicit static constructor to tell C# compiler
         /// not to mark type as beforefieldinit
@@ -49,7 +62,7 @@ namespace SentimentAnalyzer
         public static SentimentPrediction Predict(string text)
         {
             var statement = new Sentiment { Col0 = text };
-            return instance.predictionEngine.Predict(statement);
+            return Instance.predictionEngine.Predict(statement);
         }
 
     }


### PR DESCRIPTION
## Changes

- Use `[ThreadStatic]` per https://github.com/arafattehsin/CognitiveRocket/pull/3#discussion_r608661519
- Add test coverage of positive/negative sentiment

Without `[ThreadStatic]` I was seeing the following in tests running in parallel:

```
Message: 
    System.IndexOutOfRangeException : Index was outside the bounds of the array.
  Stack Trace: 
    Mapper.NormalizeSrc(ReadOnlyMemory`1& src, ReadOnlyMemory`1& dst, StringBuilder buffer)
    <>c__DisplayClass12_0.<MakeGetterOne>b__0(ReadOnlyMemory`1& dst)
    <>c__DisplayClass15_0.<MakeGetterOne>b__0(VBuffer`1& dst)
    <>c__DisplayClass13_0`2.<GetVecGetterAsCore>b__0(VBuffer`1& dst)
    <>c__DisplayClass11_0.<MakeGetter>b__2(VBuffer`1& dst)
    <>c__DisplayClass8_0.<MakeGetter>b__5(VBuffer`1& dst)
    <>c__DisplayClass20_0`1.<MakeGetter>b__0(VBuffer`1& dst)
    <>c__DisplayClass5_0.<GetGetter>b__0(VBuffer`1& dst)
    <>c__DisplayClass19_0`2.<GetValueGetter>b__0(TDst& dst)
    PredictedLabelScorerBase.EnsureCachedPosition[TScore](Int64& cachedPosition, TScore& score, DataViewRow boundRow, ValueGetter`1 scoreGetter)
    <>c__DisplayClass15_0.<GetPredictedLabelGetter>b__1(Boolean& dst)
    <>c__DisplayClass10_0`1.<CreateDirectSetter>b__0(TRow row)
    TypedRowBase.FillValues(TRow row)
    RowImplementation.FillValues(TRow row)
    PredictionEngineBase`2.FillValues(TDst prediction)
    PredictionEngine`2.Predict(TSrc example, TDst& prediction)
    PredictionEngineBase`2.Predict(TSrc example)
    Sentiments.Predict(String text) line 52
    PredictTests.Should_Return_Negative_For_Negative_Sounding_Review() line 13
```